### PR TITLE
Proposal: split up generator and builder

### DIFF
--- a/src/main/java/com/rainbowpunch/jtdg/core/FieldDataGenerator.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/FieldDataGenerator.java
@@ -14,10 +14,6 @@ public class FieldDataGenerator<T> {
 
     private final Random random;
 
-    public FieldDataGenerator() {
-        random = new Random();
-    }
-
     public FieldDataGenerator(int generatorSeed) {
         random = new Random(generatorSeed);
     }

--- a/src/main/java/com/rainbowpunch/jtdg/core/limiters/DefaultPojoLimiter.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/limiters/DefaultPojoLimiter.java
@@ -19,11 +19,11 @@ public class DefaultPojoLimiter<T> implements Limiter<T> {
         parentAttributes.getLimiters().entrySet().stream()
                 .filter(entry -> !entry.getKey().equals(parentAttributes.getPojoClazz()))
                 .flatMap(this::flattenLimiterMap)
-                .forEach(entry -> builder.andLimitFieldWith(entry.getKey(), entry.getValue()));
+                .forEach(entry -> builder.andLimitField(entry.getKey(), entry.getValue()));
 
         parentAttributes.getAllFieldLimiterMap().entrySet().stream()
                 .map(Map.Entry::getValue)
-                .forEach(builder::andLimitAllFieldsWith);
+                .forEach(builder::andLimitAllFieldsOf);
 
         generator = builder.build();
     }

--- a/src/main/java/com/rainbowpunch/jtdg/core/limiters/DefaultPojoLimiter.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/limiters/DefaultPojoLimiter.java
@@ -2,6 +2,7 @@ package com.rainbowpunch.jtdg.core.limiters;
 
 import com.rainbowpunch.jtdg.core.PojoAttributes;
 import com.rainbowpunch.jtdg.spi.PojoGenerator;
+import com.rainbowpunch.jtdg.spi.PojoGeneratorBuilder;
 
 import java.util.Map;
 import java.util.Random;
@@ -13,19 +14,18 @@ public class DefaultPojoLimiter<T> implements Limiter<T> {
     private final PojoGenerator<T> generator;
 
     public DefaultPojoLimiter(Class<T> clazz, PojoAttributes<T> parentAttributes) {
-        this.generator = new PojoGenerator<>(clazz, parentAttributes.getRandomSeed());
-        parentAttributes.getLimiters()
-                .entrySet()
-                .stream()
+        PojoGeneratorBuilder<T> builder = new PojoGeneratorBuilder<T>(clazz, parentAttributes.getRandomSeed());
+
+        parentAttributes.getLimiters().entrySet().stream()
                 .filter(entry -> !entry.getKey().equals(parentAttributes.getPojoClazz()))
                 .flatMap(this::flattenLimiterMap)
-                .forEach(entry -> generator.andLimitField(entry.getKey(), entry.getValue()));
-        parentAttributes.getAllFieldLimiterMap()
-                .entrySet()
-                .stream()
+                .forEach(entry -> builder.andLimitFieldWith(entry.getKey(), entry.getValue()));
+
+        parentAttributes.getAllFieldLimiterMap().entrySet().stream()
                 .map(Map.Entry::getValue)
-                .forEach(generator::andLimitAllFieldsOf);
-        generator.analyzePojo();
+                .forEach(builder::andLimitAllFieldsWith);
+
+        generator = builder.build();
     }
 
     private Stream<Map.Entry<String, Limiter<?>>> flattenLimiterMap(Map.Entry<Class, Map<String, Limiter<?>>> entry) {

--- a/src/main/java/com/rainbowpunch/jtdg/core/limiters/primitive/CharacterLimiter.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/limiters/primitive/CharacterLimiter.java
@@ -1,5 +1,6 @@
 package com.rainbowpunch.jtdg.core.limiters.primitive;
 
+import com.rainbowpunch.jtdg.core.limiters.Limiter;
 import com.rainbowpunch.jtdg.core.limiters.ObjectLimiter;
 import com.rainbowpunch.jtdg.util.ReadableCharList;
 
@@ -10,7 +11,7 @@ import java.util.function.Supplier;
 /**
  *
  */
-public class CharacterLimiter extends ObjectLimiter<Character> {
+public class CharacterLimiter extends ObjectLimiter<Character> implements Limiter<Character> {
 
     @Override
     protected List<Character> configureObjectList() {

--- a/src/main/java/com/rainbowpunch/jtdg/core/limiters/primitive/StringLimiter.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/limiters/primitive/StringLimiter.java
@@ -1,5 +1,6 @@
 package com.rainbowpunch.jtdg.core.limiters.primitive;
 
+import com.rainbowpunch.jtdg.core.limiters.Limiter;
 import com.rainbowpunch.jtdg.core.limiters.ObjectLimiter;
 import com.rainbowpunch.jtdg.util.ReadableCharList;
 
@@ -12,7 +13,7 @@ import java.util.stream.IntStream;
 /**
  *
  */
-public class StringLimiter extends ObjectLimiter<String> {
+public class StringLimiter extends ObjectLimiter<String> implements Limiter<String> {
 
     private final Integer length;
 

--- a/src/main/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributes.java
+++ b/src/main/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributes.java
@@ -2,6 +2,7 @@ package com.rainbowpunch.jtdg.core.reflection;
 
 import java.lang.reflect.Field;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * A friendly wrapper for Field objects.
@@ -37,6 +38,24 @@ public class FieldAttributes {
             f.setAccessible(true);
             try {
                 f.set(instance, value);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    /**
+     * Constructs a getter function that is capable of retrieving the value of a field on a provided instance.
+     * @param <T> the instance type of the object.
+     * @param <R> the value type of the field in the object.
+     * @return a function that accepts an instance and returns a field value.
+     */
+    public <T, R> Function<T, R> getGetter() {
+        final Field f = field;
+        return instance -> {
+            f.setAccessible(true);
+            try {
+                return (R) f.get(instance);
             } catch (IllegalAccessException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/com/rainbowpunch/jtdg/spi/PojoGenerator.java
+++ b/src/main/java/com/rainbowpunch/jtdg/spi/PojoGenerator.java
@@ -1,114 +1,18 @@
 package com.rainbowpunch.jtdg.spi;
 
-import com.rainbowpunch.jtdg.core.DefaultPojoAnalyzer;
-import com.rainbowpunch.jtdg.core.FieldDataGenerator;
-import com.rainbowpunch.jtdg.core.PojoAnalyzer;
-import com.rainbowpunch.jtdg.core.PojoAttributes;
-import com.rainbowpunch.jtdg.core.limiters.Limiter;
-
-import java.lang.reflect.ParameterizedType;
 import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- *
- */
-public class PojoGenerator<T> implements Cloneable {
-    private Class<T> pojo;
-    private Integer randomSeed;
+import static java.util.stream.Collectors.toList;
 
-    private PojoAnalyzer<T> pojoAnalyzer;
-    private FieldDataGenerator fieldDataGenerator;
-    private PojoAttributes<T> pojoAttributes;
+public interface PojoGenerator<T> {
+    T generatePojo();
 
-    /**
-     * Constructor is used internally for cloning purposes.
-     */
-    private PojoGenerator() {
-
-    }
-
-    public PojoGenerator(Class<T> clazz) {
-        this(clazz, new Random().nextInt());
-    }
-
-    public PojoGenerator(Class<T> clazz, Integer randomSeed) {
-        this.pojo = clazz;
-        this.randomSeed = randomSeed;
-
-        pojoAnalyzer = new DefaultPojoAnalyzer<>();
-        pojoAttributes = new PojoAttributes<>(clazz, randomSeed);
-        fieldDataGenerator = randomSeed == null ? new FieldDataGenerator() : new FieldDataGenerator(randomSeed);
-    }
-
-    public PojoGenerator<T> andLimitField(String fieldName, Limiter<?> limiter) {
-        pojoAttributes.putFieldLimiter(fieldName, limiter);
-        return this;
-    }
-
-    public PojoGenerator<T> andLimitField(List<String> fieldNames, Limiter<?> limiter) {
-        fieldNames.forEach(name -> this.andLimitField(name, limiter));
-        return this;
-    }
-
-    public PojoGenerator<T> andLimitAllFieldsOf(Limiter<?> limiter) {
-        Class clazz = ((Class) ((ParameterizedType) limiter.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0]);
-        pojoAttributes.putAllFieldLimiter(clazz, limiter);
-        return this;
-    }
-
-    public PojoGenerator<T> andIgnoreField(String fieldName) {
-        pojoAttributes.ignoreField(fieldName);
-        return this;
-    }
-
-    /**
-     * This method populates the PojoAttributes with the needed fieldSetters and dataGenerators
-     *      necessary to create Pojos on demand.
-     */
-    public PojoGenerator<T> analyzePojo() {
-        pojoAnalyzer.parsePojo(pojo, pojoAttributes);
-        fieldDataGenerator.populateSuppliers(pojoAttributes);
-        return this;
-    }
-
-    public Stream<T> generatePojoStream() {
+    default Stream<T> generatePojoStream() {
         return Stream.generate(this::generatePojo);
     }
 
-    public List<T> generatePojoList(int count) {
-        return generatePojoStream()
-                .limit(count)
-                .collect(Collectors.toList());
+    default List<T> generatePojoList(int length) {
+        return generatePojoStream().limit(length).collect(toList());
     }
-
-    public T generatePojo() {
-        try {
-            T newInstance = pojo.newInstance();
-            pojoAttributes.apply(newInstance);
-            return newInstance;
-        } catch (Exception e) {
-            throw new RuntimeException("Error generating pojo", e);
-        }
-    }
-
-    @Override
-    public PojoGenerator<T> clone() {
-        PojoGenerator generator = new PojoGenerator();
-
-        try {
-            generator.pojo = Class.forName(this.pojo.getName());
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to clone objects: ", e);
-        }
-        generator.randomSeed = this.randomSeed;
-        generator.pojoAnalyzer = new DefaultPojoAnalyzer<>();
-        generator.pojoAttributes = this.pojoAttributes.clone();
-        generator.fieldDataGenerator = new FieldDataGenerator(randomSeed);
-
-        return generator;
-    }
-
 }

--- a/src/main/java/com/rainbowpunch/jtdg/spi/PojoGeneratorBuilder.java
+++ b/src/main/java/com/rainbowpunch/jtdg/spi/PojoGeneratorBuilder.java
@@ -5,6 +5,7 @@ import com.rainbowpunch.jtdg.core.FieldDataGenerator;
 import com.rainbowpunch.jtdg.core.PojoAnalyzer;
 import com.rainbowpunch.jtdg.core.PojoAttributes;
 import com.rainbowpunch.jtdg.core.limiters.Limiter;
+import com.rainbowpunch.jtdg.core.reflection.ClassAttributes;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.Random;
@@ -13,8 +14,8 @@ import static java.util.Objects.requireNonNull;
 
 public final class PojoGeneratorBuilder<T> implements Cloneable {
     private final Class<T> clazz;
-    private final int randomSeed;
     private final PojoAttributes<T> pojoAttributes;
+    private int randomSeed;
     private PojoAnalyzer<T> pojoAnalyzer = new DefaultPojoAnalyzer<>();
 
     public PojoGeneratorBuilder(Class<T> clazz) {
@@ -32,7 +33,7 @@ public final class PojoGeneratorBuilder<T> implements Cloneable {
         this.pojoAnalyzer = pojoAnalyzer;
     }
 
-    public PojoGeneratorBuilder<T> andLimitFieldWith(String fieldName, Limiter<?> limiter) {
+    public PojoGeneratorBuilder<T> andLimitField(String fieldName, Limiter<?> limiter) {
         pojoAttributes.putFieldLimiter(fieldName, limiter);
         return this;
     }
@@ -42,7 +43,8 @@ public final class PojoGeneratorBuilder<T> implements Cloneable {
         return this;
     }
 
-    public PojoGeneratorBuilder<T> andLimitAllFieldsWith(Limiter<?> limiter) {
+    public PojoGeneratorBuilder<T> andLimitAllFieldsOf(Limiter<?> limiter) {
+        System.out.println(limiter.getClass().getGenericInterfaces().length);
         Class clazz = ((Class) ((ParameterizedType) limiter.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0]);
         pojoAttributes.putAllFieldLimiter(clazz, limiter);
         return this;
@@ -50,6 +52,11 @@ public final class PojoGeneratorBuilder<T> implements Cloneable {
 
     public PojoGeneratorBuilder<T> andUseAnalyzer(PojoAnalyzer<T> pojoAnalyzer) {
         this.pojoAnalyzer = requireNonNull(pojoAnalyzer);
+        return this;
+    }
+
+    public PojoGeneratorBuilder<T> andUseRandomSeed(int randomSeed) {
+        this.randomSeed = randomSeed;
         return this;
     }
 

--- a/src/main/java/com/rainbowpunch/jtdg/spi/PojoGeneratorBuilder.java
+++ b/src/main/java/com/rainbowpunch/jtdg/spi/PojoGeneratorBuilder.java
@@ -1,0 +1,74 @@
+package com.rainbowpunch.jtdg.spi;
+
+import com.rainbowpunch.jtdg.core.DefaultPojoAnalyzer;
+import com.rainbowpunch.jtdg.core.FieldDataGenerator;
+import com.rainbowpunch.jtdg.core.PojoAnalyzer;
+import com.rainbowpunch.jtdg.core.PojoAttributes;
+import com.rainbowpunch.jtdg.core.limiters.Limiter;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Random;
+
+import static java.util.Objects.requireNonNull;
+
+public final class PojoGeneratorBuilder<T> implements Cloneable {
+    private final Class<T> clazz;
+    private final int randomSeed;
+    private final PojoAttributes<T> pojoAttributes;
+    private PojoAnalyzer<T> pojoAnalyzer = new DefaultPojoAnalyzer<>();
+
+    public PojoGeneratorBuilder(Class<T> clazz) {
+        this(clazz, new Random().nextInt());
+    }
+
+    public PojoGeneratorBuilder(Class<T> clazz, int randomSeed) {
+        this(clazz, randomSeed, new PojoAttributes<>(clazz, randomSeed), new DefaultPojoAnalyzer<>());
+    }
+
+    private PojoGeneratorBuilder(Class<T> clazz, int randomSeed, PojoAttributes<T> pojoAttributes, PojoAnalyzer<T> pojoAnalyzer) {
+        this.clazz = clazz;
+        this.randomSeed = randomSeed;
+        this.pojoAttributes = pojoAttributes;
+        this.pojoAnalyzer = pojoAnalyzer;
+    }
+
+    public PojoGeneratorBuilder<T> andLimitFieldWith(String fieldName, Limiter<?> limiter) {
+        pojoAttributes.putFieldLimiter(fieldName, limiter);
+        return this;
+    }
+
+    public PojoGeneratorBuilder<T> andIgnoreField(String fieldName) {
+        pojoAttributes.ignoreField(fieldName);
+        return this;
+    }
+
+    public PojoGeneratorBuilder<T> andLimitAllFieldsWith(Limiter<?> limiter) {
+        Class clazz = ((Class) ((ParameterizedType) limiter.getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0]);
+        pojoAttributes.putAllFieldLimiter(clazz, limiter);
+        return this;
+    }
+
+    public PojoGeneratorBuilder<T> andUseAnalyzer(PojoAnalyzer<T> pojoAnalyzer) {
+        this.pojoAnalyzer = requireNonNull(pojoAnalyzer);
+        return this;
+    }
+
+    public PojoGenerator<T> build() {
+        pojoAnalyzer.parsePojo(clazz, pojoAttributes);
+        new FieldDataGenerator<T>(randomSeed).populateSuppliers(pojoAttributes);
+        return () -> {
+            try {
+                T newInstance = clazz.newInstance();
+                pojoAttributes.apply(newInstance);
+                return newInstance;
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    @Override
+    public PojoGeneratorBuilder<T> clone() {
+        return new PojoGeneratorBuilder<>(clazz, randomSeed, pojoAttributes.clone(), pojoAnalyzer);
+    }
+}

--- a/src/test/java/com/rainbowpunch/jtdg/core/PojoGeneratorImplTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/PojoGeneratorImplTest.java
@@ -21,23 +21,24 @@ import com.rainbowpunch.jtdg.core.limiters.ObjectLimiter;
 import com.rainbowpunch.jtdg.core.limiters.RegexLimiter;
 import com.rainbowpunch.jtdg.core.limiters.collections.ListLimiter;
 import com.rainbowpunch.jtdg.core.test.Pojos.Extra;
-import com.rainbowpunch.jtdg.core.test.Pojos.Person;
 import com.rainbowpunch.jtdg.core.test.Pojos.Storyline;
 import com.rainbowpunch.jtdg.core.test.Pojos.Superhero;
 import com.rainbowpunch.jtdg.spi.PojoGenerator;
+import com.rainbowpunch.jtdg.spi.PojoGeneratorBuilder;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  *
  */
-public class PojoGeneratorTest {
+public class PojoGeneratorImplTest {
     @Test
     public void testGenerateEmptyPojo() {
         // TODO test that all relevant fields have been set properly (use seed)
         assertNotNull(
-                new PojoGenerator<>(Extra.class)
-                        .analyzePojo()
+                new PojoGeneratorBuilder<>(Extra.class)
+                        .build()
                         .generatePojo()
         );
     }
@@ -46,8 +47,8 @@ public class PojoGeneratorTest {
     public void testGeneratePojo() {
         // TODO test that all relevant fields have been set properly (use seed)
         assertNotNull(
-                new PojoGenerator<>(Person.class)
-                        .analyzePojo()
+                new PojoGeneratorBuilder<>(Extra.class)
+                        .build()
                         .generatePojo()
         );
     }
@@ -55,8 +56,8 @@ public class PojoGeneratorTest {
     @Test
     public void testGenerateNestedPojo() {
         // TODO more comprehensive testing for subfields (use seed)
-        final Storyline storyline = new PojoGenerator<>(Storyline.class)
-                .analyzePojo()
+        final Storyline storyline = new PojoGeneratorBuilder<>(Storyline.class)
+                .build()
                 .generatePojo();
 
         assertNotNull(storyline.getSuperhero());
@@ -66,9 +67,10 @@ public class PojoGeneratorTest {
     @Test
     public void testGenerateListPojo() {
         // TODO more comprehensive testing for sublist (use seed)
-        final Superhero superhero = new PojoGenerator<>(Superhero.class)
-                .analyzePojo()
+        final Superhero superhero = new PojoGeneratorBuilder<>(Superhero.class)
+                .build()
                 .generatePojo();
+
         assertNotNull(superhero.getSuperPowers());
     }
 
@@ -82,13 +84,13 @@ public class PojoGeneratorTest {
         e2.setValue1("World");
         e2.setValue2(100);
 
-        PojoGenerator<ClassAchild> generator = new PojoGenerator<>(ClassAchild.class)
-                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
-                .andLimitField("echildlist", new ListLimiter(2, 4))
-                .andLimitAllFieldsOf(new BigDecimalLimiter())
-                .analyzePojo();
+        PojoGenerator<ClassAchild> generator = new PojoGeneratorBuilder<>(ClassAchild.class)
+                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
+                .andLimitFieldWith("echildlist", new ListLimiter(2, 4))
+                .andLimitAllFieldsWith(new BigDecimalLimiter())
+                .build();
 
         ClassAchild objA = generator.generatePojo();
 
@@ -116,11 +118,11 @@ public class PojoGeneratorTest {
         e2.setValue1("World");
         e2.setValue2(100);
 
-        PojoGenerator<ClassAchild> generator = new PojoGenerator<>(ClassAchild.class)
-                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
-                .analyzePojo();
+        PojoGenerator<ClassAchild> generator = new PojoGeneratorBuilder<>(ClassAchild.class)
+                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
+                .build();
 
         List<ClassAchild> listOfObjA = new ArrayList<>();
         List<Long> buildTime = new ArrayList<>();
@@ -176,14 +178,14 @@ public class PojoGeneratorTest {
         e2.setValue1("World");
         e2.setValue2(100);
 
-        PojoGenerator<ClassAchild> baseGen = new PojoGenerator<>(ClassAchild.class, 196809462)
-                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitAllFieldsOf(new BigDecimalLimiter())
-                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)));
+        PojoGeneratorBuilder<ClassAchild> baseGen = new PojoGeneratorBuilder<>(ClassAchild.class, 196809462)
+                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitAllFieldsWith(new BigDecimalLimiter())
+                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)));
 
-        PojoGenerator<ClassAchild> generator1 = baseGen.clone().analyzePojo();
-        PojoGenerator<ClassAchild> generator2 = baseGen.clone().analyzePojo();
+        PojoGenerator<ClassAchild> generator1 = baseGen.clone().build();
+        PojoGenerator<ClassAchild> generator2 = baseGen.clone().build();
 
         ClassAchild classA1 = generator1.generatePojo();
         ClassAchild classA2 = generator2.generatePojo();
@@ -204,7 +206,7 @@ public class PojoGeneratorTest {
                             field.setAccessible(true);
                             List<?> objects = (List<?>) field.get(object);
                             objects.stream()
-                                    .forEach(PojoGeneratorTest::classFieldsNotNull);
+                                    .forEach(PojoGeneratorImplTest::classFieldsNotNull);
                         } catch (Exception e) {
                             fail(e.getMessage());
                         }

--- a/src/test/java/com/rainbowpunch/jtdg/core/PojoGeneratorImplTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/PojoGeneratorImplTest.java
@@ -20,9 +20,9 @@ import com.rainbowpunch.jtdg.core.limiters.NestedLimiter;
 import com.rainbowpunch.jtdg.core.limiters.ObjectLimiter;
 import com.rainbowpunch.jtdg.core.limiters.RegexLimiter;
 import com.rainbowpunch.jtdg.core.limiters.collections.ListLimiter;
-import com.rainbowpunch.jtdg.core.test.Pojos.Extra;
-import com.rainbowpunch.jtdg.core.test.Pojos.Storyline;
-import com.rainbowpunch.jtdg.core.test.Pojos.Superhero;
+import com.rainbowpunch.jtdg.test.Pojos.Extra;
+import com.rainbowpunch.jtdg.test.Pojos.Storyline;
+import com.rainbowpunch.jtdg.test.Pojos.Superhero;
 import com.rainbowpunch.jtdg.spi.PojoGenerator;
 import com.rainbowpunch.jtdg.spi.PojoGeneratorBuilder;
 
@@ -34,47 +34,6 @@ import org.junit.Test;
  */
 public class PojoGeneratorImplTest {
     @Test
-    public void testGenerateEmptyPojo() {
-        // TODO test that all relevant fields have been set properly (use seed)
-        assertNotNull(
-                new PojoGeneratorBuilder<>(Extra.class)
-                        .build()
-                        .generatePojo()
-        );
-    }
-
-    @Test
-    public void testGeneratePojo() {
-        // TODO test that all relevant fields have been set properly (use seed)
-        assertNotNull(
-                new PojoGeneratorBuilder<>(Extra.class)
-                        .build()
-                        .generatePojo()
-        );
-    }
-
-    @Test
-    public void testGenerateNestedPojo() {
-        // TODO more comprehensive testing for subfields (use seed)
-        final Storyline storyline = new PojoGeneratorBuilder<>(Storyline.class)
-                .build()
-                .generatePojo();
-
-        assertNotNull(storyline.getSuperhero());
-        assertNotNull(storyline.getArchNemesis());
-    }
-
-    @Test
-    public void testGenerateListPojo() {
-        // TODO more comprehensive testing for sublist (use seed)
-        final Superhero superhero = new PojoGeneratorBuilder<>(Superhero.class)
-                .build()
-                .generatePojo();
-
-        assertNotNull(superhero.getSuperPowers());
-    }
-
-    @Test
     public void simpleDepthTest() {
         ClassE e1 = new ClassE();
         e1.setValue1("Hello");
@@ -85,11 +44,11 @@ public class PojoGeneratorImplTest {
         e2.setValue2(100);
 
         PojoGenerator<ClassAchild> generator = new PojoGeneratorBuilder<>(ClassAchild.class)
-                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
-                .andLimitFieldWith("echildlist", new ListLimiter(2, 4))
-                .andLimitAllFieldsWith(new BigDecimalLimiter())
+                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
+                .andLimitField("echildlist", new ListLimiter(2, 4))
+                .andLimitAllFieldsOf(new BigDecimalLimiter())
                 .build();
 
         ClassAchild objA = generator.generatePojo();
@@ -119,9 +78,9 @@ public class PojoGeneratorImplTest {
         e2.setValue2(100);
 
         PojoGenerator<ClassAchild> generator = new PojoGeneratorBuilder<>(ClassAchild.class)
-                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
+                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)))
                 .build();
 
         List<ClassAchild> listOfObjA = new ArrayList<>();
@@ -179,10 +138,10 @@ public class PojoGeneratorImplTest {
         e2.setValue2(100);
 
         PojoGeneratorBuilder<ClassAchild> baseGen = new PojoGeneratorBuilder<>(ClassAchild.class, 196809462)
-                .andLimitFieldWith("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
-                .andLimitFieldWith("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
-                .andLimitAllFieldsWith(new BigDecimalLimiter())
-                .andLimitFieldWith("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)));
+                .andLimitField("phoneNumber", new RegexLimiter("(\\d{3})-\\d{3}-\\d{4}"))
+                .andLimitField("strangeString", new NestedLimiter<>(ClassC.class, new RegexLimiter("xy[acd]{1,4}.\\s\\d{2}[^peatd]\\[")))
+                .andLimitAllFieldsOf(new BigDecimalLimiter())
+                .andLimitField("objE", ObjectLimiter.ofObjects(Arrays.asList(e1, e2)));
 
         PojoGenerator<ClassAchild> generator1 = baseGen.clone().build();
         PojoGenerator<ClassAchild> generator2 = baseGen.clone().build();

--- a/src/test/java/com/rainbowpunch/jtdg/core/reflection/ClassAttributesTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/reflection/ClassAttributesTest.java
@@ -1,10 +1,10 @@
 package com.rainbowpunch.jtdg.core.reflection;
 
-import static com.rainbowpunch.jtdg.core.test.Pojos.Extra;
-import static com.rainbowpunch.jtdg.core.test.Pojos.Person;
-import static com.rainbowpunch.jtdg.core.test.Pojos.Power;
-import static com.rainbowpunch.jtdg.core.test.Pojos.Superhero;
-import static com.rainbowpunch.jtdg.core.test.Pojos.SuperheroNetwork;
+import static com.rainbowpunch.jtdg.test.Pojos.Extra;
+import static com.rainbowpunch.jtdg.test.Pojos.Person;
+import static com.rainbowpunch.jtdg.test.Pojos.Power;
+import static com.rainbowpunch.jtdg.test.Pojos.Superhero;
+import static com.rainbowpunch.jtdg.test.Pojos.SuperheroNetwork;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributesTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributesTest.java
@@ -3,24 +3,43 @@ package com.rainbowpunch.jtdg.core.reflection;
 import static org.junit.Assert.assertEquals;
 
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
-import com.rainbowpunch.jtdg.core.test.Pojos.Person;
+import com.rainbowpunch.jtdg.core.falseDomain.ClassA;
+import com.rainbowpunch.jtdg.test.Pojos.Person;
 import junit.framework.AssertionFailedError;
 import org.junit.Test;
 
 public class FieldAttributesTest {
     @Test
     public void testFieldSetter() {
-        final FieldAttributes fieldAttributes =
+        FieldAttributes fieldAttributes =
                 ClassAttributes.create(Person.class)
                         .getFields().stream()
                         .filter(f -> "age".equals(f.getName()))
                         .findFirst().orElseThrow(AssertionFailedError::new);
 
-        final BiConsumer setter = fieldAttributes.getSetter();
-        final Person instance = new Person();
-        final int age = 29;
+        BiConsumer setter = fieldAttributes.getSetter();
+        Person instance = new Person();
+        int age = 29;
+
         setter.accept(instance, age);
         assertEquals(age, instance.getAge());
+    }
+
+    @Test
+    public void testFieldGetter() {
+        FieldAttributes fieldAttributes =
+                ClassAttributes.create(Person.class)
+                        .getFields().stream()
+                        .filter(f -> "age".equals(f.getName()))
+                        .findFirst().orElseThrow(AssertionFailedError::new);
+
+        Function<Person, Integer> getter = fieldAttributes.getGetter();
+
+        Person person = new Person();
+        person.setAge(99);
+
+        assertEquals(Integer.valueOf(person.getAge()), getter.apply(person));
     }
 }

--- a/src/test/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributesTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/reflection/FieldAttributesTest.java
@@ -1,14 +1,13 @@
 package com.rainbowpunch.jtdg.core.reflection;
 
-import static org.junit.Assert.assertEquals;
+import com.rainbowpunch.jtdg.test.Pojos.Person;
 
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-
-import com.rainbowpunch.jtdg.core.falseDomain.ClassA;
-import com.rainbowpunch.jtdg.test.Pojos.Person;
 import junit.framework.AssertionFailedError;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class FieldAttributesTest {
     @Test

--- a/src/test/java/com/rainbowpunch/jtdg/core/reflection/MemberAttributesTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/core/reflection/MemberAttributesTest.java
@@ -7,11 +7,11 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 
-import com.rainbowpunch.jtdg.core.test.Pojos.City;
-import com.rainbowpunch.jtdg.core.test.Pojos.Person;
-import com.rainbowpunch.jtdg.core.test.Pojos.Power;
-import com.rainbowpunch.jtdg.core.test.Pojos.Superhero;
-import com.rainbowpunch.jtdg.core.test.Pojos.SuperheroNetwork;
+import com.rainbowpunch.jtdg.test.Pojos.City;
+import com.rainbowpunch.jtdg.test.Pojos.Person;
+import com.rainbowpunch.jtdg.test.Pojos.Power;
+import com.rainbowpunch.jtdg.test.Pojos.Superhero;
+import com.rainbowpunch.jtdg.test.Pojos.SuperheroNetwork;
 import junit.framework.AssertionFailedError;
 import org.junit.Test;
 

--- a/src/test/java/com/rainbowpunch/jtdg/integration/PojoGeneratorIntegrationTest.java
+++ b/src/test/java/com/rainbowpunch/jtdg/integration/PojoGeneratorIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.rainbowpunch.jtdg.integration;
+
+import com.rainbowpunch.jtdg.core.FieldSetter;
+import com.rainbowpunch.jtdg.core.limiters.primitive.IntegerLimiter;
+import com.rainbowpunch.jtdg.core.limiters.primitive.StringLimiter;
+import com.rainbowpunch.jtdg.core.reflection.ClassAttributes;
+import com.rainbowpunch.jtdg.spi.PojoGeneratorBuilder;
+import com.rainbowpunch.jtdg.test.Pojos.Extra;
+import com.rainbowpunch.jtdg.test.Pojos.Person;
+import com.rainbowpunch.jtdg.test.Pojos.Superhero;
+import com.rainbowpunch.jtdg.test.Pojos.Vehicle;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static com.rainbowpunch.jtdg.test.Assertions.assertPojosShallowEqual;
+import static com.rainbowpunch.jtdg.test.Pojos.Power.FLIGHT;
+import static com.rainbowpunch.jtdg.test.Pojos.Power.SPIDER_SENSE;
+import static com.rainbowpunch.jtdg.test.Pojos.Power.XRAY_VISION;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PojoGeneratorIntegrationTest {
+    private static final int RANDOM_SEED = 42;
+
+    @Test
+    public void testGenerateEmptyPojo() {
+        Extra generated = new PojoGeneratorBuilder<>(Extra.class)
+                .build()
+                .generatePojo();
+
+        assertNotNull(generated);
+    }
+
+    @Test
+    public void testGenerateBasicPojo() {
+        Person generated = new PojoGeneratorBuilder<>(Person.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                .build()
+                .generatePojo();
+
+        assertEquals(-1742253836, generated.getAge());
+        assertEquals("h1<t\"c!>ya,f,0(TDja_(!DkOIfD[$", generated.getName());
+    }
+
+    @Test
+    public void testGeneratePojoWithInheritedFields() {
+        Superhero generated = new PojoGeneratorBuilder<>(Superhero.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                .build()
+                .generatePojo();
+
+        assertEquals(681416186, generated.getAge());
+        assertEquals("h1<t\"c!>ya,f,0(TDja_(!DkOIfD[$", generated.getName());
+
+        // also verify that direct fields are picked up
+        assertNotNull(generated.getSuperPowers());
+        assertNotNull(generated.getArchNemesis());
+    }
+
+    @Test
+    public void testGeneratePojoWithListField() {
+        Superhero generated = new PojoGeneratorBuilder<>(Superhero.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                .build()
+                .generatePojo();
+
+        assertEquals(
+                asList(XRAY_VISION, FLIGHT, FLIGHT, SPIDER_SENSE, SPIDER_SENSE, SPIDER_SENSE),
+                generated.getSuperPowers()
+        );
+    }
+
+    @Ignore("nested POJO does not currently inherit random seed")
+    @Test
+    public void testGeneratePojoWithNestedPojo() {
+        Person generated = new PojoGeneratorBuilder<>(Superhero.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                .build()
+                .generatePojo()
+                .getArchNemesis();
+
+        assertEquals(0, generated.getAge());
+        assertEquals("", generated.getName());
+    }
+
+    @Test
+    public void testPojoGeneratorBuilderClone() {
+        PojoGeneratorBuilder<Person> baseGen = new PojoGeneratorBuilder<>(Person.class);
+
+        Person generatedA = baseGen.clone().build().generatePojo();
+        Person generatedB = baseGen.clone().build().generatePojo();
+
+        assertPojosShallowEqual(generatedA, generatedB);
+    }
+
+    @Test
+    public void testLimitFieldByName() {
+        int expectedLength = 4;
+        Person generated = new PojoGeneratorBuilder<>(Person.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                .andLimitField("name", new StringLimiter(expectedLength))
+                .build()
+                .generatePojo();
+
+        assertEquals(expectedLength, generated.getName().length());
+    }
+
+    @Test
+    public void testLimitAllFieldsOfType() {
+        int expectedRange = 10;
+        Vehicle generated = new PojoGeneratorBuilder<>(Vehicle.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                // FIXME IntegerLimiter only matches on Integer, not int
+                .andLimitAllFieldsOf(new IntegerLimiter(expectedRange))
+                .build()
+                .generatePojo();
+
+        assertTrue(expectedRange >= generated.getMaxSpeed());
+        assertTrue(expectedRange >= generated.getNumWheels());
+    }
+
+    @Test
+    public void testUseCustomAnalyzer() {
+        Person generated;
+        generated = new PojoGeneratorBuilder<>(Person.class)
+                .andUseRandomSeed(RANDOM_SEED)
+                // use a custom analyzer that only includes string attributes
+                .andUseAnalyzer((clazz, pojoAttributes) ->
+                        ClassAttributes.create(clazz)
+                                .getFields().stream()
+                                .filter(f -> f.getType().is(String.class))
+                                .forEach(f -> {
+                                    FieldSetter<Person, String> fs = FieldSetter.create(f.getType());
+                                    fs.setConsumer(f.getSetter());
+                                    pojoAttributes.putFieldSetter(f.getName(), fs);
+                                }))
+                .build()
+                .generatePojo();
+
+        assertEquals("h1<t\"c!>ya,f,0(TDja_(!DkOIfD[$", generated.getName());
+        assertEquals(0, generated.getAge());
+    }
+}

--- a/src/test/java/com/rainbowpunch/jtdg/test/Assertions.java
+++ b/src/test/java/com/rainbowpunch/jtdg/test/Assertions.java
@@ -1,0 +1,53 @@
+package com.rainbowpunch.jtdg.test;
+
+import com.rainbowpunch.jtdg.core.reflection.ClassAttributes;
+import com.rainbowpunch.jtdg.core.reflection.FieldAttributes;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public final class Assertions {
+    private Assertions() {}
+
+    private static final Set<String> OBJECT_FIELDS;
+
+    static {
+        OBJECT_FIELDS = ClassAttributes.create(Object.class)
+                .getFields().stream()
+                .map(f -> f.getName())
+                .collect(toSet());
+    }
+
+    /**
+     * Perform a shallow comparison of two objects. If the objects are not
+     * shallowly equal, throw an AssertionError. One or both of the objects
+     * can be null.
+     * @param lhs an object to compare.
+     * @param rhs an object to compare.
+     * @param <T> the type of the objects to compare.
+     * @throws AssertionError if the objects are not equal.
+     */
+    public static <T> void assertPojosShallowEqual(T lhs, T rhs) {
+        if (Objects.equals(lhs, rhs)) {
+            return;
+        }
+        assertNotNull("left hand side is null", lhs);
+        assertNotNull("right hand side is null", rhs);
+        List<FieldAttributes> fieldAttributesList = ClassAttributes.create(lhs.getClass())
+                .getFields().stream()
+                .filter(f -> !OBJECT_FIELDS.contains(f.getName()))
+                .collect(toList());
+
+        for (FieldAttributes fa : fieldAttributesList) {
+            Function<T, ?> getter = fa.getGetter();
+            assertEquals(getter.apply(lhs), getter.apply(rhs));
+        }
+    }
+}

--- a/src/test/java/com/rainbowpunch/jtdg/test/Pojos.java
+++ b/src/test/java/com/rainbowpunch/jtdg/test/Pojos.java
@@ -1,9 +1,11 @@
-package com.rainbowpunch.jtdg.core.test;
+package com.rainbowpunch.jtdg.test;
 
 import java.util.List;
 import java.util.Map;
 
-public class Pojos {
+public final class Pojos {
+    private Pojos() {}
+
     public static class Extra { }
 
     public static class Person {
@@ -102,6 +104,36 @@ public class Pojos {
 
         public void setArchNemesis(Person archNemesis) {
             this.archNemesis = archNemesis;
+        }
+    }
+
+    public static class Vehicle {
+        private Integer maxSpeed;
+        private Integer numWheels;
+        private String name;
+
+        public Integer getMaxSpeed() {
+            return maxSpeed;
+        }
+
+        public void setMaxSpeed(Integer maxSpeed) {
+            this.maxSpeed = maxSpeed;
+        }
+
+        public Integer getNumWheels() {
+            return numWheels;
+        }
+
+        public void setNumWheels(Integer numWheels) {
+            this.numWheels = numWheels;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
     }
 }


### PR DESCRIPTION
**UPDATE**: Unit tests are added and this PR is ready for merge

I discovered (the hard way), that it is possible to call `generatePojo()` without having called `analyzePojo()` first.

This is a proposal on how to split up the logic into a builder and a generator. This prevents anyone from accidentally calling the generator without having 'built' (AKA configured) it first.

Usage is as follows:

```
PojoGenerator<MyClass> generator = new PojoGeneratorBuilder<>(MyClass.class)
    .andLimitField("foo", new SomeLimiter<>())
    .build(); // must *build* before getting back an object that you can call generatePojo() on.

generator.generatePojo();
```