### PR TITLE
Allow ConstantValueLimiter to accept a Supplier

### DIFF
--- a/src/main/java/com/rainbowpunch/jetedge/core/limiters/common/ConstantValueLimiter.java
+++ b/src/main/java/com/rainbowpunch/jetedge/core/limiters/common/ConstantValueLimiter.java
@@ -2,17 +2,80 @@ package com.rainbowpunch.jetedge.core.limiters.common;
 
 import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * This limiter allows you to set a single value to be used instead of any random value.
+ * This limiter allows you to set a single value to be used instead of any random value.  Alternatively, you
+ * can also use this to provide your own Supplier or Function for value production.
+ *
+ * <h3>Basic Constant Value Example</h3>
+ * <pre>{@code
+ *     // will always return "a value"
+ *     ConstantValueLimiter<String> cvl = new ConstantValueLimiter<String>("a value");
+ * }</pre>
+ *
+ * <h3>Supplier Example</h3>
+ * <pre>{@code
+ *     // will call supplier.get() to get the value
+ *     Supplier<String> supplier = new MySupplier();
+ *     ConstantValueLimiter<String> cvlFn = new ConstantValueLimiter<String>(supplier);
+ *
+ *     // use a local method as the value supplier
+ *     MyObject o = new MyObject();
+ *     o.myMethod(); // yields "abc" or some other value.
+ *     // will call o.myMethod() to get the value
+ *     ConstantValueLimiter<String> cvlFn = new ConstantValueLimiter<String>(o::myMethod);
+ * }</pre>
+ *
+ * <h3>Function Example</h3>
+ * <p>
+ *     The benefit to using a Function<Random,?> over a Supplier<?> is realized when you need to use
+ *     random data in your supplier.  By accepting the Random as a parameter to your function, you are
+ *     able to ensure the stability of your return values (when random is properly seeded).
+ * </p>
+ * <pre>{@code
+ *     Function<Random, Integer> myFn = random -> random.nextInt() * 777;
+ *     // will call myFn.apply(<seeded random>) to get the value.
+ *     ConstantValueLimiter<String> cvlFn = new ConstantValueLimiter<String>(myFn);
+ * }</pre>
  */
 public class ConstantValueLimiter<T> extends ObjectLimiter<T> {
 
-    private final T object;
+    private final Function<Random, T> function;
 
+    /**
+     * Construct a new {@link ConstantValueLimiter} which will return the same
+     * value every time it's called.
+     *
+     * @param object the value to return
+     */
     public ConstantValueLimiter(T object) {
-        this.object = object;
+        this(() -> object);
+    }
+
+    /**
+     * Construct a new {@link ConstantValueLimiter} with your own {@link Supplier}.  This
+     * supplier will be called each time a new value is required when populating the POJOs.
+     *
+     * @return a new instance configured to use the supplied supplier
+     * @param supplier the supplier to use when populating the POJO attributes
+     */
+    public ConstantValueLimiter(Supplier<T> supplier) {
+        this(functionFromSupplier(supplier, "supplier"));
+    }
+
+    /**
+     * Creates a new {@link ConstantValueLimiter} that will call the supplied function
+     * each time a new value is required when populating the POJOs.  The function includes the random used
+     * for generating random values.  This allows you to construct consistently random values from the
+     * seeded random object.
+     *
+     * @return a new instance configured to use the supplied function
+     * @param function The function to call when
+     */
+    public ConstantValueLimiter(Function<Random, T> function) {
+        this.function = required(function, "function");
     }
 
     @Override
@@ -22,6 +85,29 @@ public class ConstantValueLimiter<T> extends ObjectLimiter<T> {
 
     @Override
     public Supplier<T> generateSupplier(Random random) {
-        return () -> this.object;
+        return () -> this.function.apply(random);
+    }
+
+    /**
+     * @param supplier the supplier to wrap in a function
+     * @param name the argument name to return in the error if supplier is null
+     * @return a function that accepts a random object and calls {@link Supplier#get()}
+     */
+    private static final <S> Function<Random,S> functionFromSupplier(Supplier<S> supplier, String name) {
+        Supplier<S> s = required(supplier, name);
+        return (random -> s.get());
+    }
+
+    /**
+     * Helper method that throws an {@link IllegalArgumentException} if the supplied value is null
+     * @param val the value to check
+     * @param name the argument name to include in the exception message
+     * @return the value if non-null
+     */
+    private static final <X> X required(X val, String name) {
+        if (val == null) {
+            throw new IllegalArgumentException(name + " cannot be null");
+        }
+        return val;
     }
 }

--- a/src/test/java/com/rainbowpunch/jetedge/core/limiters/common/ConstantValueLimiterTest.java
+++ b/src/test/java/com/rainbowpunch/jetedge/core/limiters/common/ConstantValueLimiterTest.java
@@ -1,0 +1,111 @@
+package com.rainbowpunch.jetedge.core.limiters.common;
+
+import org.junit.Test;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class ConstantValueLimiterTest {
+
+    @Test
+    public void constructedWithSimpleValue() {
+        ConstantValueLimiter<String> cvl = new ConstantValueLimiter<String>("abc");
+
+        IntStream.range(0, 25).forEach(i -> {
+            String val = cvl.generateSupplier(null).get();
+            assertEquals("abc", val);
+        });
+    }
+
+    @Test
+    public void constructedWithSupplier() {
+        ConstantValueLimiter<String> cvl = new ConstantValueLimiter<String>(() -> "abc");
+
+        IntStream.range(0, 25).forEach(i -> {
+            String val = cvl.generateSupplier(null).get();
+            assertEquals("abc", val);
+        });
+    }
+
+    @Test
+    public void constructedWithRotatingSupplier() {
+        // given
+        int from = 0, to = 25;
+        List<String> zeroToTwentyFive = IntStream.range(from, to)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.toList());
+
+        Stack<String> returnValues = new Stack<>();
+        returnValues.addAll(zeroToTwentyFive);
+
+        // our supplier will simply pop a value off the stack we constructed above
+        ConstantValueLimiter<String> cvl = new ConstantValueLimiter<String>(returnValues::pop);
+
+        // when
+        List<String> returnedValues = IntStream.range(from, to)
+                .mapToObj(i -> cvl.generateSupplier(null).get())
+                .collect(Collectors.toList());
+        Collections.reverse(returnedValues); // there were popped off stack, so they'll be backwards
+
+        // then
+        assertEquals(zeroToTwentyFive, returnedValues);
+    }
+
+    @Test
+    public void constructedWithFunction() {
+        // given
+        Set<Random> received = new HashSet<>();
+
+        // our supplier will simply pop a value off the stack we constructed above
+        Function<Random, String> fn = (r) -> {
+            received.add(r);
+            return "abc";
+        };
+
+        ConstantValueLimiter<String> cvl = new ConstantValueLimiter<String>(fn);
+
+        // when
+        IntStream.range(0, 25).forEach(i -> {
+            cvl.generateSupplier(new Random()).get();
+        });
+
+        // then
+        assertEquals("We should have 25 distinct 'random' objects we received",
+                25,
+                received.size());
+    }
+
+    @Test
+    public void canBeStableWhenRandomIsSeeded() {
+        Random r = new Random(777);
+
+        // our generator function returns random boolean values as 0 and 1
+        // based on the random value supplied to us
+        Function<Random, Integer> fn = random -> Math.abs(random.nextInt()) % 2;
+
+        ConstantValueLimiter<Integer> cvl = new ConstantValueLimiter<Integer>(fn);
+        String zerosAndOnes = IntStream.range(0, 16)
+                .mapToObj(i -> cvl.generateSupplier(r).get().toString())
+                .collect(Collectors.joining());
+
+        assertEquals("1110010111110100", zerosAndOnes);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cantConstructWithNullSupplier() {
+        Supplier<String> s = null;
+        new ConstantValueLimiter<>(s);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cantConstructWithNullFunction() {
+        Function<Random, String> fn = null;
+        new ConstantValueLimiter<>(fn);
+    }
+
+}


### PR DESCRIPTION
## This ticket addressess 106 

Altered the ConstantValueLimiter to use a Function<Random,T> at its
core.  This allows the construction of a ConstantValueLimiter to be
accomplished using one of three types.

1. a constant value.
2. a Supplier<T>
3. a Function<Random,T>

This opens up the usage a little bit.  The original issue asked for the
inclusion of a Supplier constructor argument but in order to facilitate
stable random generation it seemed like a good idea to allow clients to
have access to the random value used, hence the addition of
Function<Random,T>.

I also added a unit test for the ConstantValueLimiter that should test
all cases.

*NOTE - the ConstantValueLimiter will throw an IllegalArgumentException
(IAE) if the supplied Supplier or Function are null.

Addresses Bekreth/jetedge#106
