### PR TITLE
Add checkstyle to the build.

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+"-//Puppy Crawl//DTD Suppressions 1.0//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+<suppressions>
+    <!--
+    <suppress checks="LineLength" files=".*" />
+    <suppress checks="Javadoc.*" files=".*" />
+    <suppress checks=".*" files="/spi/" />
+    <suppress checks=".*" files="/core/" />
+    <suppress checks=".*" files="/util/" />
+    -->
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rainbowpunch</groupId>
@@ -54,6 +54,7 @@
     <maven.javadoc.version>2.9.1</maven.javadoc.version>
     <maven.gpg.version>1.5</maven.gpg.version>
     <sonatype.version>1.6.7</sonatype.version>
+    <checkstyle.version>3.0.0</checkstyle.version>
 
     <!-- Dependency versions -->
     <logback.version>1.2.3</logback.version>
@@ -64,6 +65,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>2.9.0</mockito.version>
 
+    <checkstyle.suppressions.location>checkstyle-suppressions.xml</checkstyle.suppressions.location>
   </properties>
 
   <dependencies>
@@ -129,9 +131,44 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle.version}</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <configuration>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>false</failsOnError>
+              <linkXRef>false</linkXRef>
+            </configuration>
+            <goals>
+              <!-- if this is 'check' then it will fail the build if there are any errors -->
+              <goal>checkstyle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>checkstyle</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <profiles>
     <profile>


### PR DESCRIPTION
## This ticket addresses issue #118

Added the checkstyle plugin to the 'validate' phase.  However, it only
runs the 'checkstyle' target (not 'check') and so it doesn't fail the
build on errors.  This seems the most prudent place to start as there
are > 1400 errors with the default configuration.

I figure that follow up PRs could actually fix the checkstyle issues
and/or add proper exclusions and further configuration to checkstyle
itself.

I added the checkstyle-suppressions.xml with some sample patterns to
show how the checkstyle fixups could be 'layered in' instead of a
massive PR.

I also added checkstyle to the reporting section of the POM so it shows
after 'mvn site' is run.

Addresses Bekreth/jetedge#118
