### PR TITLE
Add tooling to keep track of code coverage 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>2.9.0</mockito.version>
     <jacoco.version>0.8.1</jacoco.version>
+    <surefire.version>2.15</surefire.version>
 
   </properties>
 
@@ -111,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.15</version>
+        <version>${surefire.version}</version>
         <configuration>
           <!-- Sets the VM argument line used when unit tests are run. -->
           <argLine>${surefireArgLine}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <junit.version>4.12</junit.version>
     <mockito.version>2.9.0</mockito.version>
+    <jacoco.version>0.8.1</jacoco.version>
 
   </properties>
 
@@ -107,6 +108,40 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.15</version>
+        <configuration>
+          <!-- Sets the VM argument line used when unit tests are run. -->
+          <argLine>${surefireArgLine}</argLine>
+          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
+          <skipTests>${skip.unit.tests}</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <id>pre-unit-test</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <propertyName>surefireArgLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -132,6 +167,23 @@
 
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <!-- select non-aggregate reports -->
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <profiles>
     <profile>

--- a/src/test/java/com/rainbowpunch/jetedge/core/analyzer/FieldPojoAnalyzerTest.java
+++ b/src/test/java/com/rainbowpunch/jetedge/core/analyzer/FieldPojoAnalyzerTest.java
@@ -19,6 +19,9 @@ public class FieldPojoAnalyzerTest {
         Set<String> actualFields = Analyzers.ALL_FIELDS.extractFields(ClassAttributes.create(Vehicle.class))
                 .map(FieldAttributes::getName)
                 .collect(toSet());
+        // this happens during coverage runs. let's just ignore $jacocoData
+        actualFields.remove("$jacocoData");
+        
         assertEquals(expectedFields, actualFields);
     }
 

--- a/src/test/java/com/rainbowpunch/jetedge/util/ReadableCharListImmutabilityTest.java
+++ b/src/test/java/com/rainbowpunch/jetedge/util/ReadableCharListImmutabilityTest.java
@@ -21,6 +21,7 @@ public class ReadableCharListImmutabilityTest {
         // obviously this could be an issue if someone adds a non char list
         // field but I think it's safe to cross that bridge when we get there.
         return Arrays.stream(ReadableCharList.class.getDeclaredFields())
+                .filter(f -> !f.getName().equals("$jacocoData"))
                 .map(f -> {
                     List<Character> cs = null;
                     try {

--- a/src/test/java/com/rainbowpunch/jetedge/util/ReadableCharListImmutabilityTest.java
+++ b/src/test/java/com/rainbowpunch/jetedge/util/ReadableCharListImmutabilityTest.java
@@ -24,6 +24,7 @@ public class ReadableCharListImmutabilityTest {
                 .map(f -> {
                     List<Character> cs = null;
                     try {
+                        f.setAccessible(true); // a little hackery in the name of testing
                         cs = (List<Character>) f.get(ReadableCharList.class);
                     } catch (IllegalAccessException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
## This ticket addressess #86 

## Add jacoco coverage plugin to POM

Add the jacoco plugin so that it runs during 'mvn test'.  It will also generate a coverage report when 'mvn site' is run provided 'mvn test' has been run and target/jacoco.exec exists.

Addresses Bekreth/jetedge#86

## Fix FieldPojoAnalyzerTest when run with jacoco

When Jacoco runs and gathers coverage it creates a $jacocoData on classes it's testing.  This failed the FieldPojoAnalyzerTest because it didn't know to ignore this field.  Now it does.
